### PR TITLE
Fix for zero sized ellipse object in tilemap

### DIFF
--- a/KoboldKit/KoboldKitFree/Framework/TilemapModel/TMX/KKTMXReader.m
+++ b/KoboldKit/KoboldKitFree/Framework/TilemapModel/TMX/KKTMXReader.m
@@ -347,6 +347,8 @@
 
 -(void) parseEllipseWithAttributes:(NSDictionary*)attributes
 {
+    if ([_parsingObject isKindOfClass:[KKTilemapPolyObject class]])
+        _parsingObject = [_parsingObject rectangleObjectFromPolyObject:(KKTilemapPolyObject*)_parsingObject];
 	((KKTilemapRectangleObject*)_parsingObject).ellipse = YES;
 	_parsingObject.objectType = KKTilemapObjectTypeEllipse;
 


### PR DESCRIPTION
Indeed, in _Tiled_, ellipse can be zero sized.

I use this feature to place marks on the map where dynamic objects will be added at runtime.

For exemple, in one of my map, I place coins in the map:

``` XML
[...]
 <objectgroup name="coin" width="64" height="48">
  <object x="511" y="663">
   <ellipse/>
  </object>
  <object x="531" y="663">
   <ellipse/>
  </object>
[...]
 </objectgroup>
[...]
```
