### PR TITLE
Allows to specify default and per instance layers names (fix issue #5)

### DIFF
--- a/KoboldKit/KoboldKitFree/Framework/Nodes/Tilemap/KKTilemapNode.h
+++ b/KoboldKit/KoboldKitFree/Framework/Nodes/Tilemap/KKTilemapNode.h
@@ -22,6 +22,8 @@
 	NSMutableArray* _tileLayerNodes;
 	NSMutableArray* _objectLayerNodes;
 	KKTilemap* _tilemap;
+	NSString* _mainTileLayerName;
+	NSString* _gameObjectsLayerName;
 	__weak KKTilemapTileLayerNode* _mainTileLayerNode;
 }
 
@@ -45,10 +47,29 @@
  @returns the "game objects" object layer node.  */
 @property (atomic, weak, readonly) KKTilemapObjectLayerNode* gameObjectsLayerNode;
 
-/** Creates a tilemap node from a TMX file.
+/** @returns an array containing the default main tile layer names */
++(NSArray*) defaultMainTileLayerNames;
+
+/** set the default main tile layer names array */
++(void) setDefaultMainTileLayerNames:(NSArray*)names;
+
+/** @returns an array containing the default game objects layer names */
++(NSArray*) defaultGameObjectsLayerNames;
+
+/** set the default game objects layer names array */
++(void) setDefaultGameObjectsLayerNames:(NSArray*)names;
+
+/** Creates a tilemap node from a TMX file, using default names for the main tile and game objects layers.
  @param tmxFile The filename of a TMX file in the bundle or an absolute path to a TMX file. 
  @returns The new instance. */
 +(id) tilemapWithContentsOfFile:(NSString*)tmxFile;
+
+/** Creates a tilemap node from a TMX file, using the specified names for the main tile and game objects layers.
+ @param tmxFile The filename of a TMX file in the bundle or an absolute path to a TMX file.
+ @param mainTileLayerName The main tile layer name to use instead of the defaults
+ @param gameObjectsLayerName The game objects name to use instead of the defaults
+ @returns The new instance. */
++(id) tilemapWithContentsOfFile:(NSString*)tmxFile usingMainTileLayerNamed:(NSString*)mainTileLayerName andGameObjectsLayerNamed:(NSString*)gameObjectsLayerName;
 
 /** @param name The name identifying a tile layer.
  @returns The tile layer node with the name, or nil if there's no tile layer with that name. */


### PR DESCRIPTION
Allows to specify default and per instance names for the main tile and game objects layers when creating a tile map.

Everything is back compatible, it works like before if the new selectors are not used.

With this patch you can:

set default layer names, somewhere when the application starts or before a map is loaded using those static selectors:

```
[KKTilemapNode setDefaultMainTileLayerNames:@[@"ground", @"Ground"]];
[KKTilemapNode setDefaultGameObjectsLayerNames:@[@"Objects"]];
```

or set layer names per map instance using the overloaded factory selector:

```
KKTilemapNode *map = [KKTilemapNode tilemapWithContentsOfFile:@"desert.tmx" usingMainTileLayerNamed:@"Ground" andGameObjectsLayerNamed:@"Objects"];
```
